### PR TITLE
Fix sync-over-async blocking across service layer, JWT validation and telemetry

### DIFF
--- a/AUDIT-SYNC-OVER-ASYNC.md
+++ b/AUDIT-SYNC-OVER-ASYNC.md
@@ -1,0 +1,142 @@
+# Báo cáo audit & fix: Sync-over-Async — TripleSix.Core
+
+- **Ngày:** 2026-07-09
+- **Branch:** `feature/v9`
+- **Phạm vi:** toàn bộ solution (201 file C#, loại trừ `bin/`, `obj/`)
+- **Phương pháp:** quét pattern + workflow audit 5 góc nhìn (42 agent, mỗi finding được verify phản biện độc lập) + code review 2 vòng (csharp-reviewer, verdict cuối: **approve**)
+- **Kết quả build sau fix:** 0 error, không phát sinh warning StyleCop/nullable mới
+
+## Tóm tắt
+
+| # | File | Mức độ | Lỗi | Trạng thái |
+|---|------|--------|-----|------------|
+| 1 | `Core/AutofacModules/ServiceInterceptor.cs` | **CRITICAL** | `Wait()` block mọi async service method toàn framework | ✅ Đã fix |
+| 2 | `Core/AutofacModules/ServiceInterceptor.cs` | HIGH | Nuốt exception của method sync (silent failure) | ✅ Đã fix |
+| 3 | `Core/Identity/IdentitySecurityTokenHandler.cs` | HIGH | Fetch JWKS bằng HTTP blocking trong luồng xác thực | ✅ Đã fix |
+| 4 | `Core/Identity/IdentitySecurityTokenHandler.cs` | MEDIUM | `new HttpClient()` mỗi lần fetch (nguy cơ socket exhaustion) | ✅ Đã fix |
+| 5 | `Core/Identity/IdentitySecurityTokenHandler.cs` | MEDIUM | Cache signing key là `Dictionary` static không khoá (race condition) | ✅ Đã fix |
+| 6 | `Core/Identity/IdentitySecurityTokenHandler.cs` | MEDIUM | Cache stampede: N request cùng fetch JWKS khi cache hết hạn | ✅ Đã fix |
+| 7 | `Core/Identity/IdentitySecurityTokenHandler.cs` | LOW | Không có timeout riêng cho HTTP JWKS (mặc định 100s) | ✅ Đã fix |
+| 8 | `Core/Services/BaseService.Entity.cs` (7 chỗ) | HIGH | `task!.Wait()` trong method đã async (có 2 chỗ nằm trong vòng lặp) | ✅ Đã fix |
+| 9 | `Core/Services/StrongService.cs` (2 chỗ) | MEDIUM | `Task.WaitAll(task!)` trong method đã async | ✅ Đã fix |
+| 10 | `Core/WebApi/Extension.cs` | MEDIUM | Async lambda gán vào delegate `Action` của OpenTelemetry (async void) | ✅ Đã fix |
+| 11 | `Core/AutofacModules/ServiceInterceptor.cs` | HIGH | *(phát sinh từ fix #1)* Rò rỉ `Activity.Current` làm gãy cây trace | ✅ Đã fix |
+| 12 | `Sample/WebApi/Startup.cs` | MEDIUM | SQL sync trong callback `GetSigningKeyMethod` (Dynamic mode) | ⏳ Chờ quyết định (đổi public API) |
+
+---
+
+## Chi tiết từng lỗi
+
+### 1. ServiceInterceptor block mọi async service method — CRITICAL
+
+**Vị trí (trước fix):** `Core/AutofacModules/ServiceInterceptor.cs`, method `Intercept`.
+
+```csharp
+invocation.Proceed();
+if (invocation.ReturnValue is Task taskResult)
+    taskResult.Wait();   // block thread đến khi task xong
+```
+
+**Vấn đề:** Interceptor này được Autofac gắn cho **mọi `IService`** qua `RegisterAllService` (`Core/AutofacModules/Extension.cs`). Mọi method async của toàn bộ service layer bị chạy đồng bộ: thread request đứng chờ task xong rồi mới trả về Task (đã hoàn tất) cho caller `await`. Toàn bộ lợi ích async mất sạch; dưới tải cao gây thread-pool starvation. Lý do `Wait()` tồn tại: giữ `Activity` span (tracing) bao trọn thời gian chạy method.
+
+**Fix:** Không block nữa. Nếu method trả `Task`/`Task<T>`, thay `ReturnValue` bằng task wrapper: `await` task gốc, tag lỗi lên activity nếu fault, dispose activity trong `finally` → span vẫn đo đúng trọn thời gian chạy async. `Task<T>` được bọc qua `WrapWithResult<T>` tạo bằng `MakeGenericMethod` (có cache theo kiểu `TResult` vì đây là hot path).
+
+### 2. Interceptor nuốt exception của method sync — HIGH
+
+**Vấn đề:** Cả 3 khối `catch` cũ chỉ tag lỗi lên activity rồi kết thúc, không `throw` lại. Method **sync** ném exception → caller nhận `null`/default mà không biết có lỗi (silent failure). (Với method async, exception vẫn tới caller qua faulted task nên không lộ ra.)
+
+**Fix:** Catch → tag → dispose activity → **`throw`** lại. Đồng thời exception từ async path giờ trả **nguyên gốc** (do `await` thay vì `Wait()`), không còn bị bọc `AggregateException` — `catch (NotFoundException)` phía caller bắt được đúng như kỳ vọng.
+
+### 3. Fetch JWKS bằng HTTP blocking trong luồng xác thực — HIGH
+
+**Vị trí (trước fix):** `Core/Identity/IdentitySecurityTokenHandler.cs`, case `Jwks` trong `ValidateToken`.
+
+```csharp
+using var httpClient = new HttpClient();
+var jwksResponse = httpClient.GetStringAsync(Setting.JwksEndpoint).GetAwaiter().GetResult();
+```
+
+**Vấn đề:** Handler chạy trên đường xác thực của mọi request có JWT. Mỗi khi cache hết hạn (`SigningKeyCacheTimelife`), thread request bị block chờ network I/O → spike latency dây chuyền dưới tải.
+
+**Nguyên nhân gốc & cách fix:** `ValidateToken` (API của `ISecurityTokenValidator`) chỉ có bản sync nên không `await` được bên trong. Tuy nhiên handler được đăng ký qua `options.TokenHandlers` (`Core/WebApi/Extension.cs`), và JwtBearer trên .NET 8/9 **luôn gọi `ValidateTokenAsync`** (đã xác minh bằng decompile `Microsoft.AspNetCore.Authentication.JwtBearer` 9.0.17: nhánh `TokenHandlers` gọi `await tokenHandler.ValidateTokenAsync(...)`; đường `SecurityTokenValidators` sync đã bị đánh dấu `[Obsolete]`). Bản `ValidateTokenAsync` kế thừa từ `JwtSecurityTokenHandler` 8.16.0 chỉ là wrapper sync-giả (`Task.FromResult` bọc quanh lời gọi virtual `this.ValidateToken`).
+
+→ **Fix:** override `ValidateTokenAsync`: fetch JWKS bằng `await` thật và nạp cache (pre-warm), sau đó gọi `base.ValidateTokenAsync` → chuỗi validate cũ chạy y nguyên nhưng cache đã ấm, không còn HTTP block. Đường sync giữ `GetAwaiter().GetResult()` làm **fallback legacy** (giới hạn API, thực tế gần như không chạy vì request luôn đi qua bản async).
+
+### 4. `new HttpClient()` mỗi lần fetch — MEDIUM
+
+**Vấn đề:** Tạo rồi dispose client mỗi lần gọi để lại socket TIME_WAIT, tích tụ gây cạn socket trên server chạy lâu.
+
+**Fix:** Một `HttpClient` static dùng chung, cấu hình `SocketsHttpHandler.PooledConnectionLifetime = 5 phút` (tránh kẹt DNS cũ khi endpoint đổi IP).
+
+### 5. Cache signing key không thread-safe — MEDIUM
+
+**Vấn đề:** `static Dictionary<string, SigningKeyCacheItem>` được đọc/ghi đồng thời từ nhiều request thread không có khoá — `Dictionary` thường không an toàn khi ghi song song (có thể ném exception hoặc hỏng cấu trúc nội bộ).
+
+**Fix:** Chuyển sang `ConcurrentDictionary`, đọc bằng `TryGetValue` (helper `GetValidCacheItem` kèm kiểm tra hạn).
+
+### 6. Cache stampede khi hết hạn — MEDIUM
+
+**Vấn đề:** Đúng lúc cache expire, N request cùng thấy miss → N cuộc gọi HTTP song song đập vào identity provider trong khi chỉ cần 1.
+
+**Fix:** Double-checked locking bằng `SemaphoreSlim(1,1)` trong đường async: check ngoài khoá → `await WaitAsync()` → check lại trong khoá → chỉ request đầu fetch, các request khác chờ rồi dùng cache; `Release()` trong `finally`.
+
+### 7. Không có timeout cho HTTP JWKS — LOW
+
+**Vấn đề:** `HttpClient.Timeout` mặc định 100 giây — JWKS endpoint chậm có thể treo xác thực rất lâu.
+
+**Fix:** `Timeout = 10s` trên client dùng chung.
+
+### 8–9. `task!.Wait()` / `Task.WaitAll` trong service base — HIGH/MEDIUM
+
+**Vị trí (trước fix):**
+
+- `Core/Services/BaseService.Entity.cs`: 7 chỗ trong `Create<TResult>`, `CreateWithMapper<TResult>`, `Update<TResult>`, `UpdateWithMapper<TResult>`, `GetFirstOrDefault<TResult>`, `GetList<TResult>`, `GetPage<TResult>`
+- `Core/Services/StrongService.cs`: 2 chỗ trong `SoftDelete<TResult>`, `Restore<TResult>`
+
+```csharp
+var task = mapMethod.Invoke(result, [ServiceProvider, entity]) as Task;
+task!.Wait();          // hoặc Task.WaitAll(task!)
+```
+
+**Vấn đề:** Block chờ task `FromEntity` (mapping DTO) **trong method vốn đã `async`** — không có lý do gì để không `await`. Nặng nhất ở `GetList<TResult>` và `GetPage<TResult>` vì `Wait()` nằm trong `foreach` — block thread cho từng entity. Ngoài block, `Wait()` còn bọc exception mapping vào `AggregateException`, phá vỡ semantics catch theo kiểu ở exception middleware. (`FromEntity` là extension point public — DTO ở các app tiêu thụ có thể override thành async thật bất kỳ lúc nào.)
+
+**Fix:** Cả 9 chỗ đổi thành `await task!;`.
+
+### 10. Async void lambda trong OpenTelemetry enrich — MEDIUM
+
+**Vị trí (trước fix):** `Core/WebApi/Extension.cs`, `SetupOpenTelemetry` → `AddHttpClientInstrumentation`.
+
+```csharp
+o.EnrichWithHttpRequestMessage = async (activity, requestMessage) => { ... await requestMessage.ToCurl() ... };
+```
+
+**Vấn đề:** `EnrichWithHttpRequestMessage` có kiểu `Action<Activity, HttpRequestMessage>` — gán async lambda vào `Action` tạo ra **async void**: (a) exception ngoài `try/catch` sẽ crash process; (b) phần sau `await` chạy đua với vòng đời activity — tag `http.curl` có thể được set sau khi activity đã export (mất tag), và đọc content stream song song với việc HttpClient đang gửi request.
+
+**Fix:** Chuyển lambda về sync; gọi `ToCurl()` và **chỉ đọc `.Result` khi `IsCompletedSuccessfully`** (content dạng buffer như `StringContent`/`ByteArrayContent` hoàn thành đồng bộ — trường hợp phổ biến). Content chưa buffer thì bỏ tag thay vì block/race — trade-off bắt buộc do delegate sync của OpenTelemetry.
+
+### 11. Rò rỉ `Activity.Current` (phát sinh từ fix #1) — HIGH
+
+**Vấn đề:** Sau khi bỏ `Wait()`, `Intercept` trả về **trước khi** task xong → activity của interceptor vẫn là `Activity.Current` ở context caller; lệnh `Dispose` nằm trong async wrapper không truyền ngược ra được (ExecutionContext bị cô lập). Hậu quả: các span kế tiếp trong cùng request nhận nhầm parent là span đã kết thúc → gãy quan hệ cha-con của distributed trace. *(Lỗi do reviewer phát hiện và xác nhận bằng repro thực nghiệm trên .NET 9 — xảy ra vô điều kiện, kể cả khi task hoàn thành đồng bộ.)*
+
+**Fix:** Capture `parentActivity = Activity.Current` trước khi `StartActivity`; sau khi gán wrapper vào `ReturnValue`, khôi phục `Activity.Current = parentActivity` ngay trong frame sync của `Intercept` trước khi return.
+
+### 12. SQL sync trong callback lấy signing key — MEDIUM — ⏳ CHƯA FIX
+
+**Vị trí:** `Sample/WebApi/Startup.cs` (method `GetSigningKey`: `SqlConnection.Open()` + `ExecuteReader()`), truyền vào `AddJwtAccessToken` làm `GetSigningKeyMethod`.
+
+**Vấn đề:** Delegate `GetSigningKeyMethod` có kiểu **sync** `Func<IdentityAppsetting, JwtSecurityToken, string?>` — app nào truyền hàm chạy SQL thì SQL đó chạy đồng bộ trong luồng xác thực mỗi khi cache Dynamic hết hạn.
+
+**Hướng fix đề xuất (cần quyết định vì đổi public API của framework):** thêm delegate async `Func<..., Task<string?>>` (`GetSigningKeyMethodAsync`), pre-warm trong `ValidateTokenAsync` tương tự JWKS, giữ delegate sync cũ để không breaking; cập nhật Sample dùng `OpenAsync`/`ExecuteReaderAsync`.
+
+---
+
+## Thay đổi hành vi cần ghi release note
+
+1. **Task từ `IService` không còn hoàn thành sẵn khi trả về.** Code ở app tiêu thụ gọi service mà quên `await` trước đây vô tình vẫn chạy tuần tự (do interceptor block), giờ chạy song song thật — đúng semantics async, nhưng cần rà nếu có chỗ dựa vào hành vi cũ.
+2. **Exception từ method sync không còn bị interceptor nuốt** — trước trả `null` im lặng, giờ ném đúng exception (đây là bug fix).
+3. **Exception từ mapping/service trả nguyên gốc** thay vì `AggregateException`.
+
+## Ghi chú còn lại (ngoài phạm vi, nên xử lý đợt riêng)
+
+- Interceptor chỉ xử lý `Task`/`Task<T>`; method trả `ValueTask` sẽ không được trace-await (hiện **không có** member `IService` nào dùng `ValueTask` — dormant).
+- NuGet vulnerability có sẵn từ trước: **AutoMapper 14.0.0 (HIGH — GHSA-rvv3-g6hj-g44x)**, OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.0 (3 advisory moderate) → nên nâng version.

--- a/Core/AutofacModules/ServiceInterceptor.cs
+++ b/Core/AutofacModules/ServiceInterceptor.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Reflection;
 using Castle.DynamicProxy;
 using TripleSix.Core.Exceptions;
 using TripleSix.Core.Helpers;
@@ -10,43 +12,103 @@ namespace TripleSix.Core.AutofacModules
     /// </summary>
     internal class ServiceInterceptor : IInterceptor
     {
+        private static readonly MethodInfo _wrapWithResultMethod = typeof(ServiceInterceptor)
+            .GetMethod(nameof(WrapWithResult), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly ConcurrentDictionary<Type, MethodInfo> _wrapMethodCache = new();
+
         /// <inheritdoc/>
         public void Intercept(IInvocation invocation)
         {
-            using var activity = Activity.Current?.Source.StartActivity(
+            var parentActivity = Activity.Current;
+            var activity = parentActivity?.Source.StartActivity(
                 $"{invocation.TargetType.Name}.{invocation.Method.Name}");
+
+            try
             {
-                try
-                {
-                    invocation.Proceed();
-                    var result = invocation.ReturnValue;
-                    if (result is Task taskResult)
-                        taskResult.Wait();
-                }
-                catch (BaseException e)
-                {
-                    activity?.AddTag("error", true);
-                    activity?.AddTag("error_code", e.Code);
-                    activity?.AddTag("error_message", e.Message);
-                }
-                catch (AggregateException e)
-                {
-                    activity?.AddTag("error", true);
-                    if (e.InnerExceptions.Count == 1 && e.InnerException is BaseException exception)
-                    {
-                        activity?.AddTag("error_code", exception.Code);
-                        activity?.AddTag("error_message", exception.Message);
-                    }
-                    else
-                    {
-                        activity?.AddTag("error_message", e.FullMessage());
-                    }
-                }
-                catch (Exception e)
-                {
-                    activity?.AddTag("error", true);
-                    activity?.AddTag("error_message", e.FullMessage());
-                }
+                invocation.Proceed();
+            }
+            catch (Exception e)
+            {
+                TagError(activity, e);
+                activity?.Dispose();
+                throw;
+            }
+
+            if (invocation.ReturnValue is not Task task)
+            {
+                activity?.Dispose();
+                return;
+            }
+
+            // không block chờ task; wrap lại để giữ activity span trọn thời gian chạy async
+            var returnType = invocation.Method.ReturnType;
+            invocation.ReturnValue = returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>)
+                ? _wrapMethodCache
+                    .GetOrAdd(returnType.GetGenericArguments()[0], resultType => _wrapWithResultMethod.MakeGenericMethod(resultType))
+                    .Invoke(null, [task, activity])
+                : Wrap(task, activity);
+
+            // Intercept trả về trước khi task xong; phải trả Activity.Current về parent để
+            // các span kế tiếp của caller không bị neo vào activity chưa/đã dispose của interceptor
+            if (activity != null)
+                Activity.Current = parentActivity;
+        }
+
+        private static async Task Wrap(Task task, Activity? activity)
+        {
+            try
+            {
+                await task;
+            }
+            catch (Exception e)
+            {
+                TagError(activity, e);
+                throw;
+            }
+            finally
+            {
+                activity?.Dispose();
+            }
+        }
+
+        private static async Task<TResult> WrapWithResult<TResult>(Task<TResult> task, Activity? activity)
+        {
+            try
+            {
+                return await task;
+            }
+            catch (Exception e)
+            {
+                TagError(activity, e);
+                throw;
+            }
+            finally
+            {
+                activity?.Dispose();
+            }
+        }
+
+        private static void TagError(Activity? activity, Exception e)
+        {
+            if (activity == null) return;
+
+            activity.AddTag("error", true);
+            switch (e)
+            {
+                case BaseException baseException:
+                    activity.AddTag("error_code", baseException.Code);
+                    activity.AddTag("error_message", baseException.Message);
+                    break;
+
+                case AggregateException aggregate when aggregate.InnerExceptions.Count == 1 && aggregate.InnerException is BaseException innerException:
+                    activity.AddTag("error_code", innerException.Code);
+                    activity.AddTag("error_message", innerException.Message);
+                    break;
+
+                default:
+                    activity.AddTag("error_message", e.FullMessage());
+                    break;
             }
         }
     }

--- a/Core/Identity/IdentitySecurityTokenHandler.cs
+++ b/Core/Identity/IdentitySecurityTokenHandler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using System.Security.Claims;
@@ -16,7 +17,16 @@ namespace TripleSix.Core.Identity
     public class IdentitySecurityTokenHandler : JwtSecurityTokenHandler,
         ISecurityTokenValidator
     {
-        private static Dictionary<string, SigningKeyCacheItem> _signingKeyCaches = new();
+        private static readonly ConcurrentDictionary<string, SigningKeyCacheItem> _signingKeyCaches = new();
+        private static readonly HttpClient _jwksHttpClient = new(new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+        })
+        {
+            Timeout = TimeSpan.FromSeconds(10),
+        };
+
+        private static readonly SemaphoreSlim _jwksFetchLock = new(1, 1);
 
         /// <summary>
         /// Create instance of <see cref="IdentitySecurityTokenHandler"/>.
@@ -37,6 +47,39 @@ namespace TripleSix.Core.Identity
         /// Hàm lấy signing key.
         /// </summary>
         public Func<IdentityAppsetting, JwtSecurityToken, string?>? GetSigningKeyMethod { get; set; }
+
+        /// <inheritdoc/>
+        public override async Task<TokenValidationResult> ValidateTokenAsync(string token, TokenValidationParameters validationParameters)
+        {
+            // nạp trước JWKS bằng HTTP async, để ValidateToken sync bên dưới đọc cache mà không block thread chờ HTTP
+            if (Setting.SigningKeyMode == IdentitySigningKeyModes.Jwks)
+            {
+                if (Setting.JwksEndpoint.IsNullOrEmpty())
+                    throw new ArgumentNullException(nameof(Setting.JwksEndpoint));
+
+                var tokenData = ReadJwtToken(token);
+                var jwksCacheKey = GetJwksCacheKey(tokenData);
+                if (GetValidCacheItem(jwksCacheKey) == null)
+                {
+                    // khóa dedupe: khi cache hết hạn, chỉ 1 request fetch JWKS, các request khác chờ dùng lại cache
+                    await _jwksFetchLock.WaitAsync();
+                    try
+                    {
+                        if (GetValidCacheItem(jwksCacheKey) == null)
+                        {
+                            var jwksResponse = await _jwksHttpClient.GetStringAsync(Setting.JwksEndpoint);
+                            CacheJwksSigningKey(tokenData, jwksCacheKey, jwksResponse);
+                        }
+                    }
+                    finally
+                    {
+                        _jwksFetchLock.Release();
+                    }
+                }
+            }
+
+            return await base.ValidateTokenAsync(token, validationParameters);
+        }
 
         /// <inheritdoc/>
         public override ClaimsPrincipal ValidateToken(string token, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
@@ -61,8 +104,8 @@ namespace TripleSix.Core.Identity
                     if (GetSigningKeyMethod == null)
                         throw new ArgumentNullException(nameof(GetSigningKeyMethod));
 
-                    var dynamicCacheItem = _signingKeyCaches.ContainsKey(cacheKey) ? _signingKeyCaches[cacheKey] : null;
-                    if (dynamicCacheItem == null || DateTime.UtcNow > dynamicCacheItem.ExpiredAt)
+                    var dynamicCacheItem = GetValidCacheItem(cacheKey);
+                    if (dynamicCacheItem == null)
                     {
                         signingKey = GetSigningKeyMethod(Setting, tokenData);
                         if (signingKey.IsNullOrEmpty()) throw new ArgumentNullException(nameof(signingKey));
@@ -85,26 +128,14 @@ namespace TripleSix.Core.Identity
                     if (Setting.JwksEndpoint.IsNullOrEmpty())
                         throw new ArgumentNullException(nameof(Setting.JwksEndpoint));
 
-                    var tokenKid = tokenData.Header.Kid;
-                    var jwksCacheKey = $"{cacheKey}_{(tokenKid.IsNullOrEmpty() ? "default" : tokenKid)}";
-
-                    var jwksCacheItem = _signingKeyCaches.ContainsKey(jwksCacheKey) ? _signingKeyCaches[jwksCacheKey] : null;
-                    if (jwksCacheItem == null || DateTime.UtcNow > jwksCacheItem.ExpiredAt)
+                    var jwksCacheKey = GetJwksCacheKey(tokenData);
+                    var jwksCacheItem = GetValidCacheItem(jwksCacheKey);
+                    if (jwksCacheItem == null)
                     {
-                        using var httpClient = new HttpClient();
-                        var jwksResponse = httpClient.GetStringAsync(Setting.JwksEndpoint).GetAwaiter().GetResult();
-                        if (jwksResponse.IsNullOrEmpty()) throw new ArgumentNullException("jwks response");
-
-                        var jwks = new JsonWebKeySet(jwksResponse);
-
-                        var jwkItem = (!tokenKid.IsNullOrEmpty() ? jwks.Keys.FirstOrDefault(k => k.Kid == tokenKid) : null)
-                            ?? jwks.Keys.FirstOrDefault(k => k.Kid == issuer)
-                            ?? throw new ArgumentNullException("jwk item");
-
-                        var jwk = Newtonsoft.Json.JsonConvert.SerializeObject(jwkItem);
-                        var expiredAt = DateTime.UtcNow.AddSeconds(Setting.SigningKeyCacheTimelife);
-                        jwksCacheItem = new SigningKeyCacheItem(jwk, expiredAt);
-                        _signingKeyCaches[jwksCacheKey] = jwksCacheItem;
+                        // fallback cho đường gọi sync (ISecurityTokenValidator không có bản async);
+                        // request qua JwtBearer đi vào ValidateTokenAsync nên cache đã được nạp bằng HTTP async trước đó
+                        var jwksResponse = _jwksHttpClient.GetStringAsync(Setting.JwksEndpoint).GetAwaiter().GetResult();
+                        jwksCacheItem = CacheJwksSigningKey(tokenData, jwksCacheKey, jwksResponse);
                     }
 
                     signingKey = jwksCacheItem.SigningKey;
@@ -140,6 +171,38 @@ namespace TripleSix.Core.Identity
             }
 
             return base.ValidateToken(token, validationParameters, out validatedToken);
+        }
+
+        private static SigningKeyCacheItem? GetValidCacheItem(string cacheKey)
+        {
+            return _signingKeyCaches.TryGetValue(cacheKey, out var item) && DateTime.UtcNow <= item.ExpiredAt
+                ? item
+                : null;
+        }
+
+        private string GetJwksCacheKey(JwtSecurityToken tokenData)
+        {
+            var tokenKid = tokenData.Header.Kid;
+            return $"{Setting.SigningKeyMode}_{tokenData.Issuer}_{(tokenKid.IsNullOrEmpty() ? "default" : tokenKid)}";
+        }
+
+        private SigningKeyCacheItem CacheJwksSigningKey(JwtSecurityToken tokenData, string jwksCacheKey, string? jwksResponse)
+        {
+            if (jwksResponse.IsNullOrEmpty()) throw new ArgumentNullException("jwks response");
+
+            var jwks = new JsonWebKeySet(jwksResponse);
+            var tokenKid = tokenData.Header.Kid;
+
+            var jwkItem = (!tokenKid.IsNullOrEmpty() ? jwks.Keys.FirstOrDefault(k => k.Kid == tokenKid) : null)
+                ?? jwks.Keys.FirstOrDefault(k => k.Kid == tokenData.Issuer)
+                ?? throw new ArgumentNullException("jwk item");
+
+            var jwk = Newtonsoft.Json.JsonConvert.SerializeObject(jwkItem);
+            var expiredAt = DateTime.UtcNow.AddSeconds(Setting.SigningKeyCacheTimelife);
+            var jwksCacheItem = new SigningKeyCacheItem(jwk, expiredAt);
+            _signingKeyCaches[jwksCacheKey] = jwksCacheItem;
+
+            return jwksCacheItem;
         }
 
         private class SigningKeyCacheItem

--- a/Core/Services/BaseService.Entity.cs
+++ b/Core/Services/BaseService.Entity.cs
@@ -54,7 +54,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, createdEntity]) as Task;
-            task!.Wait();
+            await task!;
 
             return result;
         }
@@ -80,7 +80,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, entity]) as Task;
-            task!.Wait();
+            await task!;
 
             return result;
         }
@@ -108,7 +108,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, updatedEntity]) as Task;
-            task!.Wait();
+            await task!;
 
             return result;
         }
@@ -136,7 +136,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, updatedEntity]) as Task;
-            task!.Wait();
+            await task!;
 
             return result;
         }
@@ -202,7 +202,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, entity]) as Task;
-            task!.Wait();
+            await task!;
 
             return result;
         }
@@ -271,7 +271,7 @@ namespace TripleSix.Core.Services
             {
                 var item = Activator.CreateInstance<TResult>();
                 var task = mapMethod.Invoke(item, [ServiceProvider, entity]) as Task;
-                task!.Wait();
+                await task!;
 
                 items.Add(item);
             }
@@ -329,7 +329,7 @@ namespace TripleSix.Core.Services
             {
                 var item = Activator.CreateInstance<TResult>();
                 var task = mapMethod.Invoke(item, [ServiceProvider, entity]) as Task;
-                task!.Wait();
+                await task!;
 
                 items.Add(item);
             }

--- a/Core/Services/StrongService.cs
+++ b/Core/Services/StrongService.cs
@@ -85,7 +85,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, updatedEntity]) as Task;
-            Task.WaitAll(task!);
+            await task!;
             return result;
         }
 
@@ -128,7 +128,7 @@ namespace TripleSix.Core.Services
 
             var result = Activator.CreateInstance<TResult>();
             var task = mapMethod.Invoke(result, [ServiceProvider, updatedEntity]) as Task;
-            Task.WaitAll(task!);
+            await task!;
             return result;
         }
 

--- a/Core/WebApi/Extension.cs
+++ b/Core/WebApi/Extension.cs
@@ -349,7 +349,7 @@ namespace TripleSix.Core.WebApi
 
                     tracing.AddHttpClientInstrumentation(o =>
                     {
-                        o.EnrichWithHttpRequestMessage = async (activity, requestMessage) =>
+                        o.EnrichWithHttpRequestMessage = (activity, requestMessage) =>
                         {
                             if (requestMessage.RequestUri != null)
                             {
@@ -359,7 +359,11 @@ namespace TripleSix.Core.WebApi
 
                             try
                             {
-                                activity.SetTag("http.curl", await requestMessage.ToCurl());
+                                // enrich callback là Action (không hỗ trợ async); chỉ lấy curl khi task
+                                // hoàn thành sẵn (content dạng buffer), tránh async void & block thread
+                                var curlTask = requestMessage.ToCurl();
+                                if (curlTask.IsCompletedSuccessfully)
+                                    activity.SetTag("http.curl", curlTask.Result);
                             }
                             catch
                             {


### PR DESCRIPTION
## Tóm tắt
Loại bỏ toàn bộ pattern sync-over-async trong framework (11 lỗi — chi tiết trong `AUDIT-SYNC-OVER-ASYNC.md` kèm theo PR):

- **ServiceInterceptor (CRITICAL):** bỏ `taskResult.Wait()` đang block mọi async `IService` method toàn framework; bọc `Task`/`Task<T>` bằng async wrapper để Activity span vẫn đo trọn thời gian chạy; rethrow exception của method sync (trước bị nuốt im lặng); khôi phục `Activity.Current` về parent tránh gãy cây trace; cache `MakeGenericMethod` cho hot path.
- **IdentitySecurityTokenHandler (HIGH):** override `ValidateTokenAsync` để fetch JWKS bằng HTTP async (JwtBearer .NET 9 luôn gọi bản async qua `TokenHandlers` — đã xác minh bằng decompile); `HttpClient` static dùng chung + timeout 10s; cache chuyển `ConcurrentDictionary`; chống cache-stampede bằng `SemaphoreSlim` double-check.
- **BaseService.Entity + StrongService:** 9 chỗ `task!.Wait()` / `Task.WaitAll(task!)` → `await task!` (nặng nhất là trong vòng lặp `GetList<TResult>`/`GetPage<TResult>`).
- **WebApi/Extension:** bỏ async-void lambda gán vào `EnrichWithHttpRequestMessage` (delegate `Action`); chỉ đọc curl khi task `IsCompletedSuccessfully`.

## Thay đổi hành vi (release note)
1. Task từ `IService` không còn hoàn thành sẵn khi trả về — code gọi service thiếu `await` sẽ chạy song song thật.
2. Exception từ method sync không còn bị interceptor nuốt.
3. Exception trả nguyên gốc thay vì `AggregateException`.

## Kiểm chứng
- Build: 0 error, không phát sinh warning StyleCop/nullable mới.
- Audit workflow 42 agent (mỗi finding verify độc lập) + code review 2 vòng: approve.

Còn lại (chờ quyết định vì đổi public API): callback `GetSigningKeyMethod` sync → đề xuất thêm `GetSigningKeyMethodAsync` (mục 12 trong AUDIT-SYNC-OVER-ASYNC.md).