### PR TITLE
fix(identity): enforce configured JWT algorithm & fix JWKS ES256 key serialization

### DIFF
--- a/Core/Identity/IdentitySecurityTokenHandler.cs
+++ b/Core/Identity/IdentitySecurityTokenHandler.cs
@@ -145,9 +145,19 @@ namespace TripleSix.Core.Identity
                     throw new NotSupportedException($"SigningKeyMode {Setting.SigningKeyMode} không được hỗ trợ.");
             }
 
-            var algorithm = tokenData.Header.Alg;
-            if (algorithm.IsNullOrEmpty()) algorithm = Setting.Algorithm;
-            switch (algorithm)
+            // luôn dùng Setting.Algorithm làm nguồn tin cậy duy nhất để chọn loại key,
+            // không được tin vào header "alg" của token (tránh tấn công algorithm confusion,
+            // ví dụ đổi alg sang HS256 rồi dùng public key ES256/JWKS làm HMAC secret để giả mạo chữ ký)
+            if (tokenData.Header.Alg.IsNotNullOrEmpty() && tokenData.Header.Alg != Setting.Algorithm)
+            {
+                throw new SecurityTokenInvalidAlgorithmException(
+                    $"Token sử dụng algorithm {tokenData.Header.Alg} không khớp với algorithm {Setting.Algorithm} được cấu hình.");
+            }
+
+            // bắt buộc validator của Microsoft cũng chỉ chấp nhận đúng algorithm đã cấu hình (defense in depth)
+            validationParameters.ValidAlgorithms = new[] { Setting.Algorithm };
+
+            switch (Setting.Algorithm)
             {
                 case "HS256":
                     validationParameters.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey));
@@ -167,7 +177,7 @@ namespace TripleSix.Core.Identity
                     break;
 
                 default:
-                    throw new NotSupportedException($"Algorithm {algorithm} không được hỗ trợ.");
+                    throw new NotSupportedException($"Algorithm {Setting.Algorithm} không được hỗ trợ.");
             }
 
             return base.ValidateToken(token, validationParameters, out validatedToken);
@@ -190,14 +200,18 @@ namespace TripleSix.Core.Identity
         {
             if (jwksResponse.IsNullOrEmpty()) throw new ArgumentNullException("jwks response");
 
-            var jwks = new JsonWebKeySet(jwksResponse);
+            // lấy nguyên văn JSON thô của jwk khớp thay vì parse thành JsonWebKey rồi serialize lại;
+            // JsonWebKey (IdentityModel) không có attribute của Newtonsoft nên serialize ra sẽ bị PascalCase
+            // ("Kty", "X", "Y"...), làm nhánh ES256 phía trên (check "\"kty\"" chữ thường) nhận nhầm là PEM và lỗi
+            var jwks = Newtonsoft.Json.Linq.JObject.Parse(jwksResponse);
+            var keys = jwks["keys"] as Newtonsoft.Json.Linq.JArray;
             var tokenKid = tokenData.Header.Kid;
 
-            var jwkItem = (!tokenKid.IsNullOrEmpty() ? jwks.Keys.FirstOrDefault(k => k.Kid == tokenKid) : null)
-                ?? jwks.Keys.FirstOrDefault(k => k.Kid == tokenData.Issuer)
+            var jwkItem = (!tokenKid.IsNullOrEmpty() ? keys?.FirstOrDefault(k => (string?)k["kid"] == tokenKid) : null)
+                ?? keys?.FirstOrDefault(k => (string?)k["kid"] == tokenData.Issuer)
                 ?? throw new ArgumentNullException("jwk item");
 
-            var jwk = System.Text.Json.JsonSerializer.Serialize(jwkItem);
+            var jwk = Newtonsoft.Json.JsonConvert.SerializeObject(jwkItem);
             var expiredAt = DateTime.UtcNow.AddSeconds(Setting.SigningKeyCacheTimelife);
             var jwksCacheItem = new SigningKeyCacheItem(jwk, expiredAt);
             _signingKeyCaches[jwksCacheKey] = jwksCacheItem;


### PR DESCRIPTION
## Tóm tắt

Hai fix bảo mật/chức năng cho `IdentitySecurityTokenHandler`:

### 1. Chặn algorithm confusion attack (security)
Trước đây thuật toán verify được lấy từ **header `alg` của token** (attacker kiểm soát). Khi server cấu hình `ES256` (public key qua JWKS/PEM), attacker có thể gửi token `alg: HS256` khiến handler bọc chính public key vào `SymmetricSecurityKey` làm HMAC secret → giả mạo được chữ ký.

Fix:
- `Setting.Algorithm` là nguồn tin cậy duy nhất để chọn loại key; token có header `alg` khác cấu hình bị reject ngay bằng `SecurityTokenInvalidAlgorithmException`.
- Set `validationParameters.ValidAlgorithms = [Setting.Algorithm]` để tầng validator của Microsoft.IdentityModel enforce thêm lần nữa (defense in depth).

### 2. Fix nhánh JWKS + ES256 luôn fail (bug)
`CacheJwksSigningKey` serialize lại `JsonWebKey` bằng serializer object (cả Newtonsoft lẫn System.Text.Json đều ra JSON **PascalCase** — `"Kty"`, `"X"`, `"Y"` — vì class không có JSON attribute). Check `signingKey.Contains("\"kty\"")` ở nhánh ES256 vì vậy luôn false → rơi vào nhánh PEM → `ECDsa.ImportFromPem` throw. Hệ quả: mọi token ES256 qua `SigningKeyMode = Jwks` đều fail.

Fix: parse JWKS response bằng LINQ-to-JSON và cache **raw JWK JSON** của key khớp `kid` (giữ nguyên fallback kid → issuer), nên `new JsonWebKey(rawJson)` nhận đúng field lowercase chuẩn.

## Kiểm chứng
- `dotnet build Core/Core.csproj`: 0 lỗi, không phát sinh warning mới.
- Probe e2e (console app tham chiếu Core): serve JWKS qua HttpListener local, ký JWT ES256 bằng key P-256 → validate PASS; token giả `alg: HS256` ký HMAC bằng chính public JWK JSON → bị reject PASS.